### PR TITLE
Changed Workfront Sandbox URL so it now works again

### DIFF
--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -51,7 +51,7 @@ class SessionTests(MockOpenHelper, TestCase):
         self.server.base_url = ''
         session = Session('test', url_template=SANDBOX_TEMPLATE)
         self.server.add(
-            url='https://test.attasksandbox.com/attask/api/unsupported/login',
+            url='https://test.preview.workfront.com/attask/api/unsupported/login',
             params='method=GET',
             response='{"data": "foo"}'
         )

--- a/workfront/session.py
+++ b/workfront/session.py
@@ -47,7 +47,7 @@ def pretty_json(data):
 ONDEMAND_TEMPLATE = '{protocol}://{domain}.attask-ondemand.com/attask/api/{api_version}'
 #: An alternate URL template that can be used when creating a
 #: :class:`~workfront.Session` to the Workfront Sandbox.
-SANDBOX_TEMPLATE = "{protocol}://{domain}.attasksandbox.com/attask/api/{api_version}"
+SANDBOX_TEMPLATE = "{protocol}://{domain}.preview.workfront.com/attask/api/{api_version}"
 HEADERS = {"Content-Type":" application/x-www-form-urlencoded;charset=utf-8"}
 
 


### PR DESCRIPTION
I recently was using your python library and found that connectivity to the Workfront Sandbox environment had stopped working.  I believe this is due to the URL changing.  Here is a small fix to resolve the issue.